### PR TITLE
Add enqueue_jobs option to config

### DIFF
--- a/lib/sidetiq/config.rb
+++ b/lib/sidetiq/config.rb
@@ -19,7 +19,17 @@ module Sidetiq
 
     # Public: Returns the current configuration used by Sidetiq.
     def config
-      @config ||= OpenStruct.new
+      @config ||= Sidetiq::Config.new
+    end
+  end
+
+  class Config < OpenStruct
+    def enqueue_jobs?
+      if enqueue_jobs.respond_to? :call
+        enqueue_jobs.call
+      else
+        enqueue_jobs
+      end
     end
   end
 
@@ -29,6 +39,7 @@ module Sidetiq
     config.lock_expire = 1000
     config.utc = false
     config.handler_pool_size = nil
+    config.enqueue_jobs = true
   end
 end
 

--- a/lib/sidetiq/handler.rb
+++ b/lib/sidetiq/handler.rb
@@ -4,6 +4,8 @@ module Sidetiq
     include Sidekiq::ExceptionHandler
 
     def dispatch(worker, tick)
+      return unless Sidetiq.config.enqueue_jobs?
+
       schedule = worker.schedule
 
       return unless schedule.schedule_next?(tick)

--- a/test/test_clock.rb
+++ b/test/test_clock.rb
@@ -115,4 +115,17 @@ class TestClock < Sidetiq::TestCase
       .with(expected_first_tick, -1, expected_first_tick.to_f).once
     clock.tick
   end
+
+  def test_does_not_enqueues_jobs_unless_enqueue_jobs
+    time = Time.local(2011, 1, 1, 1, 30)
+
+    clock.stubs(:gettime).returns(time, time + 3600)
+
+    Sidetiq.config.stubs(:enqueue_jobs?).returns(false)
+
+    Sidetiq.stubs(:workers).returns([SimpleWorker])
+
+    SimpleWorker.expects(:perform_at).never
+    clock.tick
+  end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -3,7 +3,7 @@ require_relative 'helper'
 class TestConfig < Sidetiq::TestCase
   def setup
     @saved = Sidetiq.config
-    Sidetiq.config = OpenStruct.new
+    Sidetiq.config = Sidetiq::Config.new
   end
 
   def teardown
@@ -16,6 +16,22 @@ class TestConfig < Sidetiq::TestCase
     end
 
     assert_equal 42, Sidetiq.config.test
+  end
+
+  def test_configure_enqueue_jobs
+    Sidetiq.configure do |config|
+      config.enqueue_jobs = false
+    end
+
+    assert_equal false, Sidetiq.config.enqueue_jobs?
+  end
+
+  def test_configure_enqueue_jobs_callable
+    Sidetiq.configure do |config|
+      config.enqueue_jobs = ->{ false }
+    end
+
+    assert_equal false, Sidetiq.config.enqueue_jobs?
   end
 end
 


### PR DESCRIPTION
For example, to not enqueue jobs when developing with rails locally:

``` ruby
Sidetiq.configure do |config|
  config.enqueue_jobs = !Rails.env.development?
end
```

It still schedules the jobs for easy development, just doesn't send to sidekiq on tick

I made it so that `enqueue_jobs` can be callable, but perhaps that's over the top? (I had to add a simple `Config` class to do this)
