### PR TITLE
Multiple locks on same worker but with different queue sidekiq option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 pkg
 tmp
 dump.rdb
+.idea

--- a/lib/sidetiq/api.rb
+++ b/lib/sidetiq/api.rb
@@ -89,6 +89,24 @@ module Sidetiq
       filter_set(Sidekiq::RetrySet.new, worker, &block)
     end
 
+    def namespace(obj)
+      ns = case obj
+           when ::Class
+             str = obj.name
+             if obj.sidekiq_options_hash && obj.sidekiq_options_hash['queue']
+               str << "_#{obj.sidekiq_options_hash['queue']}"
+             end
+             str
+           when ::String, ::Symbol
+             obj
+           else
+             obj.class.name
+           end
+      ns.gsub!('::', ':')
+      ns.gsub!('-', '_')
+      ns.downcase
+    end
+
     private
 
     def filter_set(set, worker, &block)

--- a/lib/sidetiq/handler.rb
+++ b/lib/sidetiq/handler.rb
@@ -28,7 +28,7 @@ module Sidetiq
     private
 
     def enqueue(worker, time, redis)
-      key      = "sidetiq:#{worker.name}"
+      key      = "sidetiq:#{Sidetiq.namespace(worker)}"
       time_f   = time.to_f
       next_run = (redis.get("#{key}:next") || -1).to_f
 

--- a/lib/sidetiq/lock/meta_data.rb
+++ b/lib/sidetiq/lock/meta_data.rb
@@ -12,14 +12,14 @@ module Sidetiq
           new(owner: OWNER, timestamp: Sidetiq.clock.gettime.to_f, key: key)
         end
 
-        def from_json(json = "")
+        def from_json(json = '')
           # Avoid TypeError when nil is passed to Sidekiq.load_json.
-          json = "" if json.nil?
+          json ||= ''
 
           hash = Sidekiq.load_json(json).symbolize_keys
           new(hash)
         rescue StandardError => e
-          if json != ""
+          if json != ''
             # Looks like garbage lock metadata, so report it.
             handle_exception(e, context: "Garbage lock meta data detected: #{json}")
           end

--- a/lib/sidetiq/lock/redis.rb
+++ b/lib/sidetiq/lock/redis.rb
@@ -56,7 +56,7 @@ module Sidetiq
           acquired = false
 
           watch(redis, key) do
-            if !redis.exists(key)
+            unless redis.exists(key)
               acquired = !!redis.multi do |multi|
                 meta = MetaData.for_new_lock(key)
                 multi.psetex(key, timeout, meta.to_json)
@@ -95,7 +95,7 @@ module Sidetiq
       def extract_key(key)
         case key
         when Class
-          "sidetiq:#{key.name}:lock"
+          "sidetiq:#{Sidetiq.namespace(key)}:lock"
         when String
           key.match(/sidetiq:(.+):lock/) ? key : "sidetiq:#{key}:lock"
         end

--- a/lib/sidetiq/middleware/history.rb
+++ b/lib/sidetiq/middleware/history.rb
@@ -39,7 +39,7 @@ module Sidetiq
 
       def save_entry_for_worker(entry, worker)
         Sidekiq.redis do |redis|
-          list_name = "sidetiq:#{worker.class.name}:history"
+          list_name = "sidetiq:#{Sidetiq.namespace(worker)}:history"
 
           redis.lpush(list_name, Sidekiq.dump_json(entry))
           redis.ltrim(list_name, 0, Sidetiq.config.worker_history - 1)

--- a/lib/sidetiq/schedulable.rb
+++ b/lib/sidetiq/schedulable.rb
@@ -42,7 +42,7 @@ module Sidetiq
 
       def get_timestamp(key)
         Sidekiq.redis do |redis|
-          (redis.get("sidetiq:#{name}:#{key}") || -1).to_f
+          (redis.get("sidetiq:#{Sidetiq.namespace(name)}:#{key}") || -1).to_f
         end
       end
     end

--- a/lib/sidetiq/schedule.rb
+++ b/lib/sidetiq/schedule.rb
@@ -19,11 +19,11 @@ module Sidetiq
 
     def method_missing(meth, *args, &block) # :nodoc:
       if IceCube::Rule.respond_to?(meth)
-        rule = IceCube::Rule.send(meth, *args, &block)
+        rule = IceCube::Rule.__send__(meth, *args, &block)
         @schedule.add_recurrence_rule(rule)
         rule
       elsif @schedule.respond_to?(meth)
-        @schedule.send(meth, *args, &block)
+        @schedule.__send__(meth, *args, &block)
       else
         super
       end

--- a/lib/sidetiq/web.rb
+++ b/lib/sidetiq/web.rb
@@ -41,7 +41,7 @@ module Sidetiq
         end
 
         @history = Sidekiq.redis do |redis|
-          redis.lrange("sidetiq:#{name}:history", 0, -1)
+          redis.lrange("sidetiq:#{Sidetiq.namespace(name)}:history", 0, -1)
         end
 
         erb File.read(File.join(VIEWS, 'history.erb')), locals: {view_path: VIEWS}

--- a/test/fixtures/sample_worker_with_queue.rb
+++ b/test/fixtures/sample_worker_with_queue.rb
@@ -1,0 +1,10 @@
+class SimpleWorkerWithQueue
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+  sidekiq_options queue: 'test1234'
+
+  recurrence { daily }
+
+  def perform
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,12 @@
 if RUBY_PLATFORM != "java"
+  require 'simplecov'
   require 'coveralls'
-  Coveralls.wear!
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+  ]
+  SimpleCov.start
 end
 
 require 'sidekiq'

--- a/test/test_history.rb
+++ b/test/test_history.rb
@@ -10,7 +10,7 @@ class TestHistory < Sidetiq::TestCase
     middlewared do; end
 
     entry = Sidekiq.redis do |redis|
-      redis.lrange('sidetiq:TestHistory::HistoryWorker:history', 0, -1)
+      redis.lrange('sidetiq:testhistory:historyworker:history', 0, -1)
     end
 
     actual = Sidekiq.load_json(entry[0]).symbolize_keys
@@ -34,7 +34,7 @@ class TestHistory < Sidetiq::TestCase
     end
 
     entry = Sidekiq.redis do |redis|
-      redis.lrange('sidetiq:TestHistory::HistoryWorker:history', 0, -1)
+      redis.lrange('sidetiq:testhistory:historyworker:history', 0, -1)
     end
 
     actual = Sidekiq.load_json(entry[0]).symbolize_keys

--- a/test/test_lock_redis.rb
+++ b/test/test_lock_redis.rb
@@ -54,6 +54,16 @@ class TestLockRedis < Sidetiq::TestCase
     end
   end
 
+  def test_extract_key
+    lock_redis = ::Sidetiq::Lock::Redis.new(SimpleWorker)
+    assert_equal "sidetiq:simpleworker:lock", lock_redis.instance_variable_get(:@key)
+  end
+
+  def test_extract_key_with_custom_queue
+    lock_redis = ::Sidetiq::Lock::Redis.new(SimpleWorkerWithQueue)
+    assert_equal "sidetiq:simpleworkerwithqueue_test1234:lock", lock_redis.instance_variable_get(:@key)
+  end
+
   def locked(lock_name)
     Sidetiq::Lock::Redis.new(lock_name).synchronize do |redis|
       yield redis

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -15,8 +15,8 @@ class TestWorker < Sidetiq::TestCase
     next_run = (Time.now + 100).to_f
 
     Sidekiq.redis do |redis|
-      redis.set "sidetiq:TestWorker::FakeWorker:last", last_run
-      redis.set "sidetiq:TestWorker::FakeWorker:next", next_run
+      redis.set "sidetiq:testworker:fakeworker:last", last_run
+      redis.set "sidetiq:testworker:fakeworker:next", next_run
     end
 
     assert FakeWorker.last_scheduled_occurrence == last_run


### PR DESCRIPTION
Add support for running same worker on different machines if we has dynamic queue.
Test case:
We has different workers what need notify master node what they are live. Queue name set to the hostname of node.
