### PR TITLE
Start counting at Time.now and make test independent

### DIFF
--- a/lib/sidetiq/schedule.rb
+++ b/lib/sidetiq/schedule.rb
@@ -10,7 +10,13 @@ module Sidetiq
     # Public: Start time offset from epoch used for calculating run
     # times in the Sidetiq schedules.
     def self.start_time
-      Sidetiq.config.utc ? Time.utc(2010, 1, 1) : Time.local(2010, 1, 1)
+      year, month, day = beginning_of_times.year, beginning_of_times.month, beginning_of_times.day
+
+      Sidetiq.config.utc ? Time.utc(year, month, day) : Time.local(year, month, day)
+    end
+
+    def self.beginning_of_times
+      Time.now
     end
 
     def initialize # :nodoc:

--- a/test/test_clock.rb
+++ b/test/test_clock.rb
@@ -1,6 +1,10 @@
 require_relative 'helper'
 
 class TestClock < Sidetiq::TestCase
+  def before
+    Sidetiq::Schedule.stubs(:beginning_of_times).returns(Time.new(2014, 1, 1))
+  end
+
   def test_gettime_seconds
     assert_equal clock.gettime.tv_sec, Time.now.tv_sec
   end
@@ -38,18 +42,18 @@ class TestClock < Sidetiq::TestCase
     SimpleWorker.expects(:perform_at).times(10)
 
     10.times do |i|
-      clock.stubs(:gettime).returns(Time.local(2011, 1, i + 1, 1))
+      clock.stubs(:gettime).returns(Time.local(2015, 1, i + 1, 1))
       clock.tick
     end
 
-    clock.stubs(:gettime).returns(Time.local(2011, 1, 10, 2))
+    clock.stubs(:gettime).returns(Time.local(2015, 1, 10, 2))
     clock.tick
     clock.tick
     clock.tick
   end
 
   def test_enqueues_jobs_with_default_last_tick_arg_on_first_run
-    time = Time.local(2011, 1, 1, 1, 30)
+    time = Time.local(2015, 1, 1, 1, 30)
 
     clock.stubs(:gettime).returns(time, time + 3600)
 
@@ -67,7 +71,7 @@ class TestClock < Sidetiq::TestCase
   end
 
   def test_enqueues_jobs_with_last_run_timestamp_and_next_run_timestamp
-    time = Time.local(2011, 1, 1, 1, 30)
+    time = Time.local(2015, 1, 1, 1, 30)
 
     clock.stubs(:gettime).returns(time, time + 3600)
 
@@ -89,7 +93,7 @@ class TestClock < Sidetiq::TestCase
   end
 
   def test_enqueues_jobs_with_last_run_timestamp_if_optional_argument
-    time = Time.local(2011, 1, 1, 1, 30)
+    time = Time.local(2015, 1, 1, 1, 30)
 
     clock.stubs(:gettime).returns(time, time + 3600)
 
@@ -103,7 +107,7 @@ class TestClock < Sidetiq::TestCase
   end
 
   def test_enqueues_jobs_correctly_for_splat_args_perform_methods
-    time = Time.local(2011, 1, 1, 1, 30)
+    time = Time.local(2015, 1, 1, 1, 30)
 
     clock.stubs(:gettime).returns(time, time + 3600)
 

--- a/test/test_schedule.rb
+++ b/test/test_schedule.rb
@@ -37,7 +37,8 @@ class TestSchedule < Sidetiq::TestCase
 
   def test_use_utc
     Sidetiq.config.utc = true
-    assert_equal(Time.utc(2010, 01, 01), Sidetiq::Schedule.new.start_time)
+    Sidetiq::Schedule.stubs(:beginning_of_times).returns(Time.new(2014, 1, 1))
+    assert_equal(Time.utc(2014, 01, 01), Sidetiq::Schedule.start_time)
   ensure
     Sidetiq.config.utc = false
   end

--- a/test/test_sidetiq.rb
+++ b/test/test_sidetiq.rb
@@ -1,6 +1,10 @@
 require_relative 'helper'
 
 class TestSidetiq < Sidetiq::TestCase
+  def before
+    Sidetiq::Schedule.stubs(:beginning_of_times).returns(Time.new(2014, 1, 1))
+  end
+
   def test_schedules
     schedules = Sidetiq.schedules
 
@@ -20,7 +24,7 @@ class TestSidetiq < Sidetiq::TestCase
 
   def test_scheduled
     client = Sidekiq::Client.new
-    SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
+    SimpleWorker.perform_at(Time.local(2015, 1, 1, 1))
     hash = SimpleWorker.jobs.first
     client.push_old(hash.merge("at" => hash["enqueued_at"]))
 
@@ -37,7 +41,7 @@ class TestSidetiq < Sidetiq::TestCase
 
   def test_scheduled_given_arguments
     client = Sidekiq::Client.new
-    SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
+    SimpleWorker.perform_at(Time.local(2015, 1, 1, 1))
     hash = SimpleWorker.jobs.first
     client.push_old(hash.merge("at" => hash["enqueued_at"]))
 
@@ -50,11 +54,11 @@ class TestSidetiq < Sidetiq::TestCase
 
   def test_scheduled_yields_each_job
     client = Sidekiq::Client.new
-    SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
+    SimpleWorker.perform_at(Time.local(2015, 1, 1, 1))
     hash = SimpleWorker.jobs.first
     client.push_old(hash.merge("at" => hash["enqueued_at"]))
 
-    ScheduledWorker.perform_at(Time.local(2011, 1, 1, 1))
+    ScheduledWorker.perform_at(Time.local(2015, 1, 1, 1))
     hash = ScheduledWorker.jobs.first
     client.push_old(hash.merge("at" => hash["enqueued_at"]))
 


### PR DESCRIPTION
The hardcoded startup time at 2010 make the sidekiq process burn 100% CPU during a long time on startup. Related issue #117
