### PR TITLE
No method error raising for nil runtime

### DIFF
--- a/lib/sidetiq/views/history.erb
+++ b/lib/sidetiq/views/history.erb
@@ -23,10 +23,11 @@
 
         <% @history.each do |entry| %>
         <% entry = Sidekiq.load_json(entry).symbolize_keys %>
+        <% runtime = entry[:runtime]&.round(3) || "N/A" %>
         <tr class="<%= 'error' if entry[:status] == 'failure' %>">
           <td><%= entry[:status].capitalize %></td>
           <td><%= Time.parse(entry[:timestamp]).strftime("%m/%d/%Y %I:%M:%S%p") %></td>
-          <td><%= entry[:runtime].round(3) %> s</td>
+          <td><%= runtime %> s</td>
           <td>
             <% if entry[:status] == 'failure' %>
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">


### PR DESCRIPTION
Problem: When runtime is nil, a no method error is raised for round on nil:NilClass when attempting to view the job history page for a recurring job.

Solution: Use lonely operator to handle nil value for runtime and display N/A in these cases.

@jimmydo and I encountered this error when we upgraded sidetiq today.