### PR TITLE
Repair runtime on history page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ branches:
 services:
   - redis-server
 rvm:
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - jruby-19mode
   - rbx-19mode
   - ruby-head
@@ -17,9 +19,9 @@ jdk:
   - oraclejdk7
 matrix:
   exclude:
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       jdk: openjdk7
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       jdk: openjdk6
     - rvm: rbx-19mode
       jdk: openjdk7

--- a/lib/sidetiq/views/history.erb
+++ b/lib/sidetiq/views/history.erb
@@ -23,7 +23,7 @@
 
         <% @history.each do |entry| %>
         <% entry = Sidekiq.load_json(entry).symbolize_keys %>
-        <% runtime = entry[:runtime]&.round(3) || "N/A" %>
+        <% runtime = entry[:runtime].nil? ? 'N/A' : entry[:runtime].round(3) %>
         <tr class="<%= 'error' if entry[:status] == 'failure' %>">
           <td><%= entry[:status].capitalize %></td>
           <td><%= Time.parse(entry[:timestamp]).strftime("%m/%d/%Y %I:%M:%S%p") %></td>


### PR DESCRIPTION
fixes #164 by removing the usage of the safe nav operator (`&.`). This allows the history page to fully work for ruby versions < 2.3.
