### PR TITLE
Fixes ::Fixnum deprecation warnings

### DIFF
--- a/sidetiq.gemspec
+++ b/sidetiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'sidekiq',   '>= 4.1.0'
   gem.add_dependency 'celluloid', '>= 0.17.3'
-  gem.add_dependency 'ice_cube',  '~> 0.14.0'
+  gem.add_dependency 'ice_cube',  '~> 0.16.3'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sinatra'


### PR DESCRIPTION
Changes in ice_cube since 0.14.0 appear to be backwards compatible so upgrading is simple